### PR TITLE
default to first role in list or aws_admin_role if no role specified

### DIFF
--- a/aws-assume-role
+++ b/aws-assume-role
@@ -95,8 +95,13 @@ aws-assume-role() {
     local accountid region
 
     if [[ -z "$role" ]]; then
-        echo "usage: aws-assume-role <accountid> <role>"
-        return 1
+        # default to first in list
+        role=$(jq -r ".[\"${accountname}\"].roles[0]" < ~/.aws/accounts)
+        if [[ -z $role ]] || [[ "$role" == "null" ]]; then
+            # default if no roles in list
+            role="aws_admin_role"
+        fi
+        echo "No role specified, defaulting to ${role}"
     fi
 
     accountid=$(jq -r ".[\"${accountname}\"].id" < ~/.aws/accounts)


### PR DESCRIPTION
if you just have one role for an account, this defaults to that role. if you have no roles specified, this defaults to the default that we already use for autocompletion, `aws_admin_role`.